### PR TITLE
Showing station simple view using PartialSheet package

### DIFF
--- a/evinfo.xcodeproj/project.pbxproj
+++ b/evinfo.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -25,6 +25,9 @@
 		809DBBD826FF78030002D1EF /* StationListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809DBBD726FF78030002D1EF /* StationListItem.swift */; };
 		809DBBDA270038870002D1EF /* StationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809DBBD9270038870002D1EF /* StationList.swift */; };
 		809DBBDC27004DFF0002D1EF /* StationRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809DBBDB27004DFF0002D1EF /* StationRowView.swift */; };
+		809DBBE0270EFE5A0002D1EF /* StationAnnotationProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809DBBDF270EFE5A0002D1EF /* StationAnnotationProtocol.swift */; };
+		809DBBE2270F07E50002D1EF /* StationSimpleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809DBBE1270F07E50002D1EF /* StationSimpleView.swift */; };
+		809DBBE5270F2B750002D1EF /* PartialSheet in Frameworks */ = {isa = PBXBuildFile; productRef = 809DBBE4270F2B750002D1EF /* PartialSheet */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -51,6 +54,8 @@
 		809DBBD726FF78030002D1EF /* StationListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListItem.swift; sourceTree = "<group>"; };
 		809DBBD9270038870002D1EF /* StationList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationList.swift; sourceTree = "<group>"; };
 		809DBBDB27004DFF0002D1EF /* StationRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationRowView.swift; sourceTree = "<group>"; };
+		809DBBDF270EFE5A0002D1EF /* StationAnnotationProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationAnnotationProtocol.swift; sourceTree = "<group>"; };
+		809DBBE1270F07E50002D1EF /* StationSimpleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationSimpleView.swift; sourceTree = "<group>"; };
 		962C61DDA6DF1A1644362C40 /* Pods-evinfo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-evinfo.release.xcconfig"; path = "Target Support Files/Pods-evinfo/Pods-evinfo.release.xcconfig"; sourceTree = "<group>"; };
 		ABAA70732DCBDC9A4EB0ED28 /* Pods-evinfo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-evinfo.debug.xcconfig"; path = "Target Support Files/Pods-evinfo/Pods-evinfo.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -60,6 +65,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				809DBBE5270F2B750002D1EF /* PartialSheet in Frameworks */,
 				034460B20287EBF6D9848AC2 /* Pods_evinfo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -95,12 +101,14 @@
 				809DBBB826F47BC60002D1EF /* MapView.swift */,
 				809DBBD526FF57A60002D1EF /* StationListView.swift */,
 				809DBBDB27004DFF0002D1EF /* StationRowView.swift */,
+				809DBBE1270F07E50002D1EF /* StationSimpleView.swift */,
 				809DBBBA26F47FC30002D1EF /* LocationHelper.swift */,
 				809DBBBC26F4ADC80002D1EF /* Location.swift */,
 				809DBBC226F9FC910002D1EF /* ChargerList.swift */,
 				809DBBC026F9FB660002D1EF /* ChargerListItem.swift */,
 				809DBBD9270038870002D1EF /* StationList.swift */,
 				809DBBD726FF78030002D1EF /* StationListItem.swift */,
+				809DBBDF270EFE5A0002D1EF /* StationAnnotationProtocol.swift */,
 				809DBBC626FC4EE00002D1EF /* GoogleMapView.swift */,
 				809DBBAA26F478B20002D1EF /* Assets.xcassets */,
 				809DBBAF26F478B20002D1EF /* LaunchScreen.storyboard */,
@@ -164,6 +172,9 @@
 			dependencies = (
 			);
 			name = evinfo;
+			packageProductDependencies = (
+				809DBBE4270F2B750002D1EF /* PartialSheet */,
+			);
 			productName = evinfo;
 			productReference = 809DBB9E26F478B10002D1EF /* evinfo.app */;
 			productType = "com.apple.product-type.application";
@@ -191,6 +202,9 @@
 				Base,
 			);
 			mainGroup = 809DBB9526F478B10002D1EF;
+			packageReferences = (
+				809DBBE3270F2B750002D1EF /* XCRemoteSwiftPackageReference "PartialSheet" */,
+			);
 			productRefGroup = 809DBB9F26F478B10002D1EF /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -263,11 +277,13 @@
 				809DBBBB26F47FC30002D1EF /* LocationHelper.swift in Sources */,
 				809DBBA226F478B10002D1EF /* AppDelegate.swift in Sources */,
 				809DBBD626FF57A60002D1EF /* StationListView.swift in Sources */,
+				809DBBE0270EFE5A0002D1EF /* StationAnnotationProtocol.swift in Sources */,
 				809DBBA426F478B10002D1EF /* SceneDelegate.swift in Sources */,
 				809DBBC326F9FC910002D1EF /* ChargerList.swift in Sources */,
 				809DBBB926F47BC60002D1EF /* MapView.swift in Sources */,
 				809DBBDC27004DFF0002D1EF /* StationRowView.swift in Sources */,
 				809DBBA926F478B10002D1EF /* evinfo.xcdatamodeld in Sources */,
+				809DBBE2270F07E50002D1EF /* StationSimpleView.swift in Sources */,
 				809DBBC726FC4EE00002D1EF /* GoogleMapView.swift in Sources */,
 				809DBBC126F9FB660002D1EF /* ChargerListItem.swift in Sources */,
 				809DBBD826FF78030002D1EF /* StationListItem.swift in Sources */,
@@ -473,6 +489,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		809DBBE3270F2B750002D1EF /* XCRemoteSwiftPackageReference "PartialSheet" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/AndreaMiotto/PartialSheet.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.1.14;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		809DBBE4270F2B750002D1EF /* PartialSheet */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 809DBBE3270F2B750002D1EF /* XCRemoteSwiftPackageReference "PartialSheet" */;
+			productName = PartialSheet;
+		};
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCVersionGroup section */
 		809DBBA726F478B10002D1EF /* evinfo.xcdatamodeld */ = {

--- a/evinfo/ChargerList.swift
+++ b/evinfo/ChargerList.swift
@@ -10,17 +10,17 @@ import Combine
 
 class ChargerList: ObservableObject {
     init() {
-        getStationInformation(latitude:37.55108, longitude:126.94096, size:30)
+        getChargerInfo(latitude:37.55108, longitude:126.94096, size:30)
     }
     init(latitude: Double, longitude: Double, size: Int){
-        getStationInformation(latitude:latitude, longitude:longitude, size:size)
+        getChargerInfo(latitude:latitude, longitude:longitude, size:size)
     }
     
     @Published var items: [ChargerListItem] = []
     var canclelables = Set<AnyCancellable>()
     
     // Method
-    func getStationInformation(latitude: Double, longitude: Double, size: Int) {
+    func getChargerInfo(latitude: Double, longitude: Double, size: Int) {
         guard let url = URL(string: "http://ec2-3-35-112-56.ap-northeast-2.compute.amazonaws.com:8080/api/chargers?latitude=\(latitude)&longitude=\(longitude)&size=\(size)") else { return }
         
         URLSession.shared.dataTaskPublisher(for: url)
@@ -96,5 +96,6 @@ class ChargerList: ObservableObject {
         for _ in 0..<items.count {
             items.remove(at: 0)
         }
+        print("clear charger list")
     }
 }

--- a/evinfo/ContentView.swift
+++ b/evinfo/ContentView.swift
@@ -6,15 +6,18 @@
 //  init
 
 import SwiftUI
+import PartialSheet
 
 struct ContentView: View {
     @StateObject var chargerList = ChargerList()
     @StateObject var stationList = StationList()
+    @StateObject var sheetManager: PartialSheetManager = PartialSheetManager()
     
     var body: some View {
         MapView()
             .environmentObject(chargerList)
             .environmentObject(stationList)
+            .environmentObject(sheetManager)
     }
 }
 

--- a/evinfo/MapView.swift
+++ b/evinfo/MapView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import MapKit
+import PartialSheet
 
 struct MapView: View {
     // initialize region
@@ -27,84 +28,121 @@ struct MapView: View {
     
     // station list view flag
     @State private var showingStationListSheet = false
+    // station simple view flag
+    @State private var showingStationSimpleSheet = false
 
     @EnvironmentObject var chargerList: ChargerList
     @EnvironmentObject var stationList: StationList
     
+    // clicked station marker(pin)
+    @StateObject var selectedStation = StationListItem()
+    
+    // partial sheet (Station Simple View) manager
+    @EnvironmentObject var partialSheetManager: PartialSheetManager
+    
     var body: some View {
         ZStack{
-            Map(coordinateRegion: $region, interactionModes: .all, showsUserLocation: true, userTrackingMode: .constant(trackingMode), annotationItems: chargerList.items) {
+            Map(coordinateRegion: $region, interactionModes: .all, showsUserLocation: true, userTrackingMode: .constant(trackingMode), annotationItems: stationList.items) {
                 items in
-                MapMarker(coordinate: CLLocationCoordinate2D(latitude: items.lat, longitude: items.lng), tint: Color.purple)
+                //MapMarker(coordinate: CLLocationCoordinate2D(latitude: items.lat, longitude: items.lng), tint: Color.purple)
+                StationAnnotationProtocol(MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: items.lat, longitude: items.lng)) {
+                    Image(systemName: "mappin.circle")
+                        .resizable()
+                        .frame(width: 30, height: 30)
+                        .foregroundColor(.green)
+                        .onTapGesture {
+                            selectedStation.copyStation(toItem: selectedStation, fromItem: items)
+                            showingStationSimpleSheet = true
+                            print(items.stationName)
+                        }
+                })
             }
+            .partialSheet(isPresented: $showingStationSimpleSheet){
+                StationSimpleView().environmentObject(selectedStation)
+            }
+            .addPartialSheet()
             .onAppear(){
                 curLocation = LocationHelper.currentLocation
                 region = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: curLocation.latitude, longitude: curLocation.longitude), span: MKCoordinateSpan(latitudeDelta: MapDefault.zoom, longitudeDelta: MapDefault.zoom))
                 print(curLocation)
-                chargerList.getStationInformation(latitude: curLocation.latitude, longitude: curLocation.longitude, size: 30)
-            }
-
-            // user tracking mode button
-            VStack(spacing: 10){
-                Spacer()
-                HStack{
-                    Spacer()
-                    Button(action: {
-                        showingStationListSheet = true
-                    }) {
-                        Image(systemName: "list.bullet")
-                    }
-                    .font(.system(size:25))
-                    .foregroundColor(.blue)
-                    .frame(width: 40, height: 40)
-                    .background(Color.white)
-                    .cornerRadius(10)
-                    .fullScreenCover(isPresented: $showingStationListSheet, content: {
-                        StationListView().environmentObject(chargerList)
-                            .environmentObject(stationList)
-                    })
-                }
-                HStack{
-                    Spacer()
-                    Button(action: {
-                        chargerList.clearChargerList()
-                        curLocation = LocationHelper.currentLocation
-                        region = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: curLocation.latitude, longitude: curLocation.longitude), span: MKCoordinateSpan(latitudeDelta: MapDefault.zoom, longitudeDelta: MapDefault.zoom))
-                        chargerList.getStationInformation(latitude: curLocation.latitude, longitude: curLocation.longitude, size: 30)
-                    }) {
-                        Image(systemName: "arrow.clockwise")
-                    }
-                    .font(.system(size:25))
-                    .foregroundColor(.blue)
-                    .frame(width: 40, height: 40)
-                    .background(Color.white)
-                    .cornerRadius(10)
-                }
-                HStack{
-                    Spacer()
-                    Button(action: {
-                        if trackingMode == .none {
-                            trackingMode = .follow
-                        }
-                        else {
-                            trackingMode = .none
-                        }
-                    }) {
-                        if trackingMode == .none {
-                            Image(systemName: "location.fill")
-                        }
-                        else {
-                            Image(systemName: "location")
-                        }
-                    }
-                    .font(.system(size:25))
-                    .foregroundColor(.blue)
-                    .frame(width: 40, height: 40)
-                    .background(Color.white)
-                    .cornerRadius(10)
+                chargerList.clearChargerList()
+                stationList.clearStationList()
+                chargerList.getChargerInfo(latitude: curLocation.latitude, longitude: curLocation.longitude, size: 30)
+                if chargerList.items.count > 0 {
+                    stationList.getStationInfo(chargerList: chargerList)
                 }
             }
-            .padding()
+            
+            if showingStationSimpleSheet == false {
+                VStack(spacing: 10){
+                    Spacer()
+                    HStack{
+                        Spacer()
+                        // showing station list view button
+                        Button(action: {
+                            showingStationListSheet = true
+                        }) {
+                            Image(systemName: "list.bullet")
+                        }
+                        .font(.system(size:25))
+                        .foregroundColor(.blue)
+                        .frame(width: 40, height: 40)
+                        .background(Color.white)
+                        .cornerRadius(10)
+                        .fullScreenCover(isPresented: $showingStationListSheet, content: {
+                            StationListView().environmentObject(chargerList)
+                                .environmentObject(stationList)
+                        })
+                    }
+                    HStack{
+                        Spacer()
+                        // refresh button
+                        Button(action: {
+                            curLocation = LocationHelper.currentLocation
+                            region = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: curLocation.latitude, longitude: curLocation.longitude), span: MKCoordinateSpan(latitudeDelta: MapDefault.zoom, longitudeDelta: MapDefault.zoom))
+                            chargerList.clearChargerList()
+                            stationList.clearStationList()
+                            chargerList.getChargerInfo(latitude: curLocation.latitude, longitude: curLocation.longitude, size: 30)
+                            if chargerList.items.count > 0 {
+                                stationList.getStationInfo(chargerList: chargerList)
+                                print("refresh")
+                            }
+                        }) {
+                            Image(systemName: "arrow.clockwise")
+                        }
+                        .font(.system(size:25))
+                        .foregroundColor(.blue)
+                        .frame(width: 40, height: 40)
+                        .background(Color.white)
+                        .cornerRadius(10)
+                    }
+                    HStack{
+                        Spacer()
+                        // user tracking mode button
+                        Button(action: {
+                            if trackingMode == .none {
+                                trackingMode = .follow
+                            }
+                            else {
+                                trackingMode = .none
+                            }
+                        }) {
+                            if trackingMode == .none {
+                                Image(systemName: "location.fill")
+                            }
+                            else {
+                                Image(systemName: "location")
+                            }
+                        }
+                        .font(.system(size:25))
+                        .foregroundColor(.blue)
+                        .frame(width: 40, height: 40)
+                        .background(Color.white)
+                        .cornerRadius(10)
+                    }
+                }
+                .padding()
+            }
         }
     } // End of body
 }

--- a/evinfo/StationAnnotationProtocol.swift
+++ b/evinfo/StationAnnotationProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  StationAnnotationProtocol.swift
+//  evinfo
+//
+//  Created by yhw on 2021/10/07.
+//
+
+import MapKit
+import SwiftUI
+
+struct StationAnnotationProtocol: MapAnnotationProtocol {
+    let _annotationData: _MapAnnotationData
+    let value: Any
+    
+    init<WrappedType: MapAnnotationProtocol>(_ value: WrappedType) {
+        self.value = value
+        _annotationData = value._annotationData
+    }
+}

--- a/evinfo/StationList.swift
+++ b/evinfo/StationList.swift
@@ -39,11 +39,13 @@ class StationList: ObservableObject  {
                 preFlag = false
             }
         }
+        print("get station info")
     }
     
     func clearStationList() {
         for _ in 0..<items.count {
             items.remove(at: 0)
         }
+        print("clear station list")
     }
 }

--- a/evinfo/StationListItem.swift
+++ b/evinfo/StationListItem.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-class StationListItem: ObservableObject  {
+class StationListItem: ObservableObject, Identifiable  {
+    let id = UUID()
     var stationId: String = "NULL"
     var stationName: String = "NULL"
     var address: String = "NULL"
@@ -36,6 +37,27 @@ class StationListItem: ObservableObject  {
     func addChargerItem(id: String, chargerType: String, chargerStat: String){
         let item = ChargerItem(id: id, chargerType: chargerType, chargerStat: chargerStat)
         self.chargerItems.append(item)
+    }
+    
+    func copyStation(toItem: StationListItem, fromItem: StationListItem) {
+        toItem.stationId = fromItem.stationId
+        toItem.stationName = fromItem.stationName
+        toItem.address = fromItem.address
+        toItem.location = fromItem.location
+        toItem.useTime = fromItem.useTime
+        toItem.lat = fromItem.lat
+        toItem.lng = fromItem.lng
+        toItem.callNumber = fromItem.callNumber
+        toItem.distance = fromItem.distance
+        
+        for _ in 0..<toItem.chargerItems.count {
+            toItem.chargerItems.remove(at: 0)
+        }
+        
+        for i in 0..<fromItem.chargerItems.count {
+            let item = fromItem.chargerItems[i]
+            toItem.chargerItems.append(item)
+        }
     }
 }
 

--- a/evinfo/StationSimpleView.swift
+++ b/evinfo/StationSimpleView.swift
@@ -1,0 +1,88 @@
+//
+//  StationSimpleView.swift
+//  evinfo
+//
+//  Created by yhw on 2021/10/07.
+//
+
+import SwiftUI
+
+struct StationSimpleView: View {
+
+    @EnvironmentObject var selectedStation: StationListItem
+    
+    @State var waitingCharger = 0
+    
+    var body: some View {
+        VStack(spacing: 10){
+            HStack{
+                Text(selectedStation.stationName)
+                    .font(.title3)
+                    .foregroundColor(.blue)
+                Spacer()
+            }.padding(.horizontal, 20)
+            HStack{
+                Text(selectedStation.address)
+                .font(.subheadline)
+                    .foregroundColor(.gray)
+                Spacer()
+            }.padding(.horizontal, 20)
+            if selectedStation.useTime.count > 0 {
+                HStack{
+                    Image(systemName: "clock")
+                    Text(selectedStation.useTime)
+                    .font(.callout)
+                    Spacer()
+                }.padding(.horizontal, 20)
+            }
+            HStack{
+                if waitingCharger > 0 {
+                    Text("충전 가능")
+                        .font(.headline)
+                        .foregroundColor(.green)
+                }
+                else {
+                    Text("충전 불가")
+                        .font(.headline)
+                        .foregroundColor(.red)
+                }
+                Spacer()
+                Text("\(waitingCharger) / \(selectedStation.chargerItems.count)")
+            }.padding(.horizontal, 20)
+            /*
+            ForEach(0..<selectedStation.chargerItems.count) {
+                i in
+                HStack{
+                    Image(systemName: "bolt.fill")
+                        .foregroundColor(.green)
+                    Text("\(selectedStation.chargerItems[i].id) : \(selectedStation.chargerItems[i].chargerStat)")
+                    Spacer()
+                }
+            }
+            */
+             
+        }.padding(.bottom, 20)
+        // onTapGesture occurs even if press the blank space
+        .background(Color.white)
+        .onTapGesture {
+            print("simple view -> detail view")
+        }
+        .onAppear(){
+            for i in 0..<selectedStation.chargerItems.count {
+                if selectedStation.chargerItems[i].chargerStat == "WAITING" {
+                    self.waitingCharger += 1
+                }
+            }
+        }
+        .onDisappear(){
+            self.waitingCharger = 0
+            print("dismiss \(selectedStation.stationName) simple view")
+        }
+    }
+}
+
+struct StationSimpleView_Previews: PreviewProvider {
+    static var previews: some View {
+        StationSimpleView()
+    }
+}


### PR DESCRIPTION
resolved: #13
---

**구현 사항**

- 사용자가 지도 위의 충전소 핀을 누를 수 있도록 `MapMarker()` 대신 `MapAnnotationProtocol`을 생성
- 핀이 눌리면 해당 충전소에 대한 간단한 정보를 보여줄 수 있는 `StationSimpleView.swift`를 생성
이때 해당 충전소에 대한 정보는 `selectedStation` 객체에 담아 `environmentObject`로 전달
- `StationSimpleView` sheet가 적당한 크기로 나타나게 구현

**특이 사항**
- `StationSimpleView` sheet가 적절한 크기를 가질 수 있도록 [PartialSheet SwiftUI package](https://github.com/AndreaMiotto/PartialSheet) 사용
    - 안정성 문제
    `PartialSheet package > Sources > PartialSheetViewModifier.swift` 에서
        > Bound preference SheetPreferenceKey tried to update multiple times perframe.
- `MapView.swift' 에서 충전소 정보 업데이트 하는 과정에서 delay 발생
이후 서버에서 구조체 형식 바꾼 뒤 정보 받아올 때 수정하여 해결 가능

