### PR TITLE
Showing station detail view

### DIFF
--- a/evinfo.xcodeproj/project.pbxproj
+++ b/evinfo.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		809DBBE0270EFE5A0002D1EF /* StationAnnotationProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809DBBDF270EFE5A0002D1EF /* StationAnnotationProtocol.swift */; };
 		809DBBE2270F07E50002D1EF /* StationSimpleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809DBBE1270F07E50002D1EF /* StationSimpleView.swift */; };
 		809DBBE5270F2B750002D1EF /* PartialSheet in Frameworks */ = {isa = PBXBuildFile; productRef = 809DBBE4270F2B750002D1EF /* PartialSheet */; };
+		809DBBE7271846350002D1EF /* StationDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809DBBE6271846350002D1EF /* StationDetailView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +55,7 @@
 		809DBBDB27004DFF0002D1EF /* StationRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationRowView.swift; sourceTree = "<group>"; };
 		809DBBDF270EFE5A0002D1EF /* StationAnnotationProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationAnnotationProtocol.swift; sourceTree = "<group>"; };
 		809DBBE1270F07E50002D1EF /* StationSimpleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationSimpleView.swift; sourceTree = "<group>"; };
+		809DBBE6271846350002D1EF /* StationDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationDetailView.swift; sourceTree = "<group>"; };
 		962C61DDA6DF1A1644362C40 /* Pods-evinfo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-evinfo.release.xcconfig"; path = "Target Support Files/Pods-evinfo/Pods-evinfo.release.xcconfig"; sourceTree = "<group>"; };
 		ABAA70732DCBDC9A4EB0ED28 /* Pods-evinfo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-evinfo.debug.xcconfig"; path = "Target Support Files/Pods-evinfo/Pods-evinfo.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -100,6 +102,7 @@
 				809DBBD526FF57A60002D1EF /* StationListView.swift */,
 				809DBBDB27004DFF0002D1EF /* StationRowView.swift */,
 				809DBBE1270F07E50002D1EF /* StationSimpleView.swift */,
+				809DBBE6271846350002D1EF /* StationDetailView.swift */,
 				809DBBBA26F47FC30002D1EF /* LocationHelper.swift */,
 				809DBBBC26F4ADC80002D1EF /* Location.swift */,
 				809DBBC026F9FB660002D1EF /* ChargerListItem.swift */,
@@ -273,6 +276,7 @@
 			files = (
 				809DBBBB26F47FC30002D1EF /* LocationHelper.swift in Sources */,
 				809DBBA226F478B10002D1EF /* AppDelegate.swift in Sources */,
+				809DBBE7271846350002D1EF /* StationDetailView.swift in Sources */,
 				809DBBD626FF57A60002D1EF /* StationListView.swift in Sources */,
 				809DBBE0270EFE5A0002D1EF /* StationAnnotationProtocol.swift in Sources */,
 				809DBBA426F478B10002D1EF /* SceneDelegate.swift in Sources */,

--- a/evinfo/ChargerListItem.swift
+++ b/evinfo/ChargerListItem.swift
@@ -15,6 +15,8 @@ struct ChargerListItem: Identifiable, Codable {
     var isAC3: Bool
     var isACSlow: Bool
     var chargerStat: String
+    var output: Int
+    var price: Float
     
     // Encode/Decode is performed except for id that allows item to be identification
     enum CodingKeys: String, CodingKey {
@@ -24,5 +26,7 @@ struct ChargerListItem: Identifiable, Codable {
         case isAC3
         case isACSlow
         case chargerStat
+        case output
+        case price
     }
 }

--- a/evinfo/MapView.swift
+++ b/evinfo/MapView.swift
@@ -36,7 +36,7 @@ struct MapView: View {
     // clicked station marker(pin)
     @StateObject var selectedStation = StationListItem()
     
-    // partial sheet (Station Simple View) manager
+    // partial sheet (Station List / Simple View) manager
     @EnvironmentObject var partialSheetManager: PartialSheetManager
     
     var body: some View {
@@ -45,7 +45,7 @@ struct MapView: View {
                 items in
                 StationAnnotationProtocol(MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: items.latitude, longitude: items.longitude)) {
                     // Station that can charge
-                    if items.state > 0 {
+                    if items.enableChargers > 0 {
                     Image(systemName: "mappin.circle")
                         .resizable()
                         .frame(width: 30, height: 30)
@@ -57,7 +57,7 @@ struct MapView: View {
                         }
                     }
                     // Station that cannot charge
-                    else if items.state == 0 {
+                    else if items.enableChargers == 0 {
                         Image(systemName: "mappin.circle")
                             .resizable()
                             .frame(width: 30, height: 30)
@@ -93,7 +93,7 @@ struct MapView: View {
                 stationList.getStationInfo(latitude: curLocation.latitude, longitude: curLocation.longitude, size: 40)
             }
             
-            if showingStationSimpleSheet == false {
+            if showingStationSimpleSheet == false && showingStationListSheet == false {
                 VStack(spacing: 10){
                     Spacer()
                     HStack(spacing: 10){
@@ -108,10 +108,11 @@ struct MapView: View {
                         .frame(width: 40, height: 40)
                         .background(Color.white)
                         .cornerRadius(10)
-                        .fullScreenCover(isPresented: $showingStationListSheet, content: {
+                        .partialSheet(isPresented: $showingStationListSheet){
                             StationListView()
                                 .environmentObject(stationList)
-                        })
+                                .environmentObject(selectedStation)
+                        }
                         Spacer()
                         
                         // refresh button
@@ -120,7 +121,6 @@ struct MapView: View {
                             region = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: curLocation.latitude, longitude: curLocation.longitude), span: MKCoordinateSpan(latitudeDelta: MapDefault.zoom, longitudeDelta: MapDefault.zoom))
                             stationList.clearStationList()
                             stationList.getStationInfo(latitude: curLocation.latitude, longitude: curLocation.longitude, size: 40)
-                            stationList.checkStationsState()
                             print("refresh")
                         }) {
                             Image(systemName: "arrow.clockwise")

--- a/evinfo/StationDetailView.swift
+++ b/evinfo/StationDetailView.swift
@@ -1,0 +1,142 @@
+//
+//  StationDetailView.swift
+//  evinfo
+//
+//  Created by yhw on 2021/10/14.
+//
+
+import SwiftUI
+
+struct StationDetailView: View {
+    
+    @EnvironmentObject var selectedStation: StationListItem
+    
+    // dismiss view flag
+    @Environment(\.presentationMode) var presentationMode
+    
+    var body: some View {
+        VStack {
+            HStack{
+                // dismiss view button
+                Button(action: {
+                    presentationMode.wrappedValue.dismiss()
+                }) {
+                    Image(systemName: "xmark")
+                        .font(.title)
+                        .foregroundColor(/*@START_MENU_TOKEN@*/.blue/*@END_MENU_TOKEN@*/)
+                        .padding(10)
+                }
+                Spacer()
+            }
+            ScrollView{
+                VStack(spacing: 10){
+                    HStack{
+                        Text(selectedStation.stationName)
+                            .font(.title3)
+                            .foregroundColor(/*@START_MENU_TOKEN@*/.blue/*@END_MENU_TOKEN@*/)
+                        Spacer()
+                    }
+                    HStack{
+                        Text(selectedStation.address)
+                        .font(.callout)
+                            .foregroundColor(.gray)
+                        Spacer()
+                    }
+                    HStack{
+                        Image(systemName: "phone.fill")
+                        Text(selectedStation.callNumber)
+                        Spacer()
+                    }
+                    HStack{
+                        Image(systemName: "building.2")
+                        Text(selectedStation.businessName)
+                            .font(.callout)
+                            Spacer()
+                    }
+                    HStack{
+                        Image(systemName: "wonsign.circle")
+                        Text("1kWh당 "+String(format: "%.1f", selectedStation.chargers[0].price)+"원")
+                            .font(.callout)
+                            Spacer()
+                    }
+                    if selectedStation.useTime.count > 0 {
+                        HStack{
+                            Image(systemName: "clock")
+                            Text(selectedStation.useTime)
+                            .font(.callout)
+                            Spacer()
+                        }
+                    }
+                    
+                    // charger list
+                    ForEach(0..<selectedStation.chargers.count){
+                        i in
+                        HStack{
+                            if selectedStation.chargers[i].chargerStat == "WAITING" {
+                                Text("충전 가능")
+                                    .font(.headline)
+                                    .foregroundColor(.green)
+                            }
+                            else if selectedStation.chargers[i].chargerStat == "CHARGING" {
+                                Text("충전 불가")
+                                    .font(.headline)
+                                    .foregroundColor(.red)
+                            }
+                            else {
+                                Text("확인 불가")
+                                    .font(.headline)
+                                    .foregroundColor(.orange)
+                            }
+                            if selectedStation.chargers[i].isDCCombo {
+                                Text("DC콤보")
+                                    .font(.headline)
+                                    .foregroundColor(.blue)
+                            }
+                            else {
+                                Text("DC콤보")
+                                    .font(.body)
+                                    .foregroundColor(.gray)
+                            }
+                            if selectedStation.chargers[i].isDCDemo {
+                                Text("DC데모")
+                                    .font(.headline)
+                                    .foregroundColor(.blue)
+                            }
+                            else {
+                                Text("DC데모")
+                                    .font(.body)
+                                    .foregroundColor(.gray)
+                            }
+                            if selectedStation.chargers[i].isAC3 {
+                                Text("AC3상")
+                                    .font(.headline)
+                                    .foregroundColor(.blue)
+                            }
+                            else {
+                                Text("AC3상")
+                                    .font(.body)
+                                    .foregroundColor(.gray)
+                            }
+                            if selectedStation.chargers[i].isACSlow {
+                                Text("완속")
+                                    .font(.headline)
+                                    .foregroundColor(.blue)
+                            }
+                            else {
+                                Text("완속")
+                                    .font(.headline)
+                                    .foregroundColor(.gray)
+                            }
+                        }
+                    } // End of ForEach
+                }
+            }.padding(.horizontal, 20)
+        }
+    }
+}
+
+struct StationDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        StationDetailView()
+    }
+}

--- a/evinfo/StationList.swift
+++ b/evinfo/StationList.swift
@@ -34,7 +34,6 @@ class StationList: ObservableObject  {
        
             .sink { completion in
                 print("Completion: \(completion)")
-                self.checkStationsState()
             } receiveValue: { [weak self] StationListItem in
                 self?.items = StationListItem
             }
@@ -58,12 +57,6 @@ class StationList: ObservableObject  {
             items.remove(at: 0)
         }
         print("clear station list")
-    }
-    
-    func checkStationsState() {
-        for i in 0..<items.count {
-            items[i].checkStationState()
-        }
     }
 }
 

--- a/evinfo/StationListItem.swift
+++ b/evinfo/StationListItem.swift
@@ -17,9 +17,10 @@ class StationListItem: Identifiable, Codable, ObservableObject {
     var latitude: Double
     var longitude: Double
     var callNumber: String
+    var businessName: String
     var distance: Float
+    var enableChargers: Int
     var chargers: [ChargerListItem] = []
-    @Published var state: Int = 1
     
     // Encode/Decode is performed except for id that allows item to be identification
     enum CodingKeys: String, CodingKey {
@@ -31,7 +32,9 @@ class StationListItem: Identifiable, Codable, ObservableObject {
         case latitude
         case longitude
         case callNumber
+        case businessName
         case distance
+        case enableChargers
         case chargers
     }
     
@@ -44,8 +47,9 @@ class StationListItem: Identifiable, Codable, ObservableObject {
         self.latitude = 37.0
         self.longitude = 126.9
         self.callNumber = "NULL"
+        self.businessName = "NULL"
         self.distance = 0.0
-        self.state = 0
+        self.enableChargers = 0
     }
     
     func copyStation(toItem: StationListItem, fromItem: StationListItem) {
@@ -57,8 +61,9 @@ class StationListItem: Identifiable, Codable, ObservableObject {
         toItem.latitude = fromItem.latitude
         toItem.longitude = fromItem.longitude
         toItem.callNumber = fromItem.callNumber
+        toItem.businessName = fromItem.businessName
         toItem.distance = fromItem.distance
-        toItem.state = fromItem.state
+        toItem.enableChargers = fromItem.enableChargers
         
         for _ in 0..<toItem.chargers.count {
             toItem.chargers.remove(at: 0)
@@ -69,19 +74,4 @@ class StationListItem: Identifiable, Codable, ObservableObject {
             toItem.chargers.append(item)
         }
     }
-    
-    func checkStationState() {
-        var waitingCharger = 0
-        for i in 0..<self.chargers.count {
-            if self.chargers[i].chargerStat == "WAITING" {
-                waitingCharger += 1
-            }
-            else if self.chargers[i].chargerStat == "CHECKING" {
-                waitingCharger = -1
-                break
-            }
-        }
-        self.state = waitingCharger
-    }
-
 }

--- a/evinfo/StationListView.swift
+++ b/evinfo/StationListView.swift
@@ -8,40 +8,28 @@
 import SwiftUI
 
 struct StationListView: View {
+
     @EnvironmentObject var stationList: StationList
+    @EnvironmentObject var selectedStation: StationListItem
     
     // dismiss view flag
     @Environment(\.presentationMode) var presentationMode
     
-    @State var stationListCount = 0
-    
     var body: some View {
         VStack{
-            HStack{
-                // dismiss view button
-                Button(action: {
-                    presentationMode.wrappedValue.dismiss()
-                }) {
-                    Image(systemName: "xmark")
-                        .font(.title)
-                        .foregroundColor(/*@START_MENU_TOKEN@*/.blue/*@END_MENU_TOKEN@*/)
-                        .padding(10)
-                }
-                Spacer()
-            }
             // show station list
             List{
                 VStack{
-                    ForEach(0..<stationListCount){
+                    ForEach(0..<stationList.items.count){
                     index in
-                        StationRowView(stationListItem: $stationList.items[index])
+                            StationRowView(stationListItem: $stationList.items[index])
+                                .environmentObject(selectedStation)
+                                .background(Color.white)
                     } // End of ForEach
                 }
             }
         }
-        .onAppear() {
-            stationListCount = stationList.items.count
-        }
+        .background(Color.white)
     } // End of View
 }
 /*

--- a/evinfo/StationRowView.swift
+++ b/evinfo/StationRowView.swift
@@ -10,6 +10,11 @@ import SwiftUI
 struct StationRowView: View {
     @Binding var stationListItem: StationListItem
     
+    @EnvironmentObject var selectedStation: StationListItem
+    
+    // station detail view flag
+    @State private var showingStationDetailSheet = false
+    
     var body: some View {
         VStack{
             HStack{
@@ -46,12 +51,12 @@ struct StationRowView: View {
                 }
             }
             HStack{
-                if stationListItem.state > 0 {
+                if stationListItem.enableChargers > 0 {
                     Text("충전 가능")
                         .font(.headline)
                         .foregroundColor(.green)
                 }
-                else if stationListItem.state == 0 {
+                else if stationListItem.enableChargers == 0 {
                     Text("충전 불가")
                         .font(.headline)
                         .foregroundColor(.red)
@@ -70,7 +75,7 @@ struct StationRowView: View {
                     Text("급속 ")
                         .font(.headline)
                 }
-                Text("\(stationListItem.state) / \(stationListItem.chargers.count)")
+                Text("\(stationListItem.enableChargers) / \(stationListItem.chargers.count)")
                     .font(.headline)
             }.padding(.bottom, 20)
             Spacer()
@@ -79,7 +84,12 @@ struct StationRowView: View {
         .background(Color.white)
         .onTapGesture {
             print(stationListItem.stationName)
+            selectedStation.copyStation(toItem: selectedStation, fromItem: stationListItem)
+            self.showingStationDetailSheet = true
         }
+        .fullScreenCover(isPresented: $showingStationDetailSheet, content: {
+            StationDetailView().environmentObject(selectedStation)
+        })
     }
 }
 /*

--- a/evinfo/StationSimpleView.swift
+++ b/evinfo/StationSimpleView.swift
@@ -11,79 +11,82 @@ struct StationSimpleView: View {
 
     @EnvironmentObject var selectedStation: StationListItem
     
+    // station detail view flag
+    @State private var showingStationDetailSheet = false
+    
     var body: some View {
-        VStack(spacing: 10){
-            HStack{
-                Text(selectedStation.stationName)
-                    .font(.title3)
-                    .foregroundColor(.blue)
-                Spacer()
-            }.padding(.horizontal, 20)
-            HStack{
-                Text(selectedStation.address)
-                .font(.subheadline)
-                    .foregroundColor(.gray)
-                Spacer()
-            }.padding(.horizontal, 20)
-            if selectedStation.useTime.count > 0 {
+        Button(action: {
+            showingStationDetailSheet = true
+        }) {
+            VStack(spacing: 10){
                 HStack{
-                    Image(systemName: "clock")
-                    Text(selectedStation.useTime)
-                    .font(.callout)
+                    Text(selectedStation.stationName)
+                        .font(.title3)
+                        .foregroundColor(.blue)
                     Spacer()
                 }.padding(.horizontal, 20)
-            }
-            HStack{
-                if selectedStation.distance < 1.0 {
-                    Text("\(Int(round(selectedStation.distance * 1000)))m")
-                        .font(.callout)
-                        .foregroundColor(.red)
+                HStack{
+                    Text(selectedStation.address)
+                    .font(.subheadline)
+                        .foregroundColor(.gray)
+                    Spacer()
+                }.padding(.horizontal, 20)
+                if selectedStation.useTime.count > 0 {
+                    HStack{
+                        Image(systemName: "clock")
+                        Text(selectedStation.useTime)
+                            .font(.callout)
+                            .foregroundColor(.black)
+                        Spacer()
+                    }.padding(.horizontal, 20)
                 }
-                else {
-                    Text(String(format: "%.1f", selectedStation.distance) + "km")
-                        .font(.callout)
-                        .foregroundColor(.red)
-                }
-                Spacer()
-            }.padding(.horizontal, 20)
-            HStack{
-                if selectedStation.state > 0 {
-                    Text("충전 가능")
+                HStack{
+                    if selectedStation.distance < 1.0 {
+                        Text("\(Int(round(selectedStation.distance * 1000)))m")
+                            .font(.callout)
+                            .foregroundColor(.red)
+                    }
+                    else {
+                        Text(String(format: "%.1f", selectedStation.distance) + "km")
+                            .font(.callout)
+                            .foregroundColor(.red)
+                    }
+                    Spacer()
+                }.padding(.horizontal, 20)
+                HStack{
+                    if selectedStation.enableChargers > 0 {
+                        Text("충전 가능")
+                            .font(.headline)
+                            .foregroundColor(.green)
+                    }
+                    else if selectedStation.enableChargers == 0 {
+                        Text("충전 불가")
+                            .font(.headline)
+                            .foregroundColor(.red)
+                    }
+                    else {
+                        Text("확인 불가")
+                            .font(.headline)
+                            .foregroundColor(.orange)
+                    }
+                    Spacer()
+                    if selectedStation.chargers[0].isACSlow {
+                        Text("완속 ")
+                            .font(.headline)
+                    }
+                    else {
+                        Text("급속 ")
+                            .font(.headline)
+                    }
+                    Text("\(selectedStation.enableChargers) / \(selectedStation.chargers.count)")
                         .font(.headline)
-                        .foregroundColor(.green)
-                }
-                else if selectedStation.state == 0 {
-                    Text("충전 불가")
-                        .font(.headline)
-                        .foregroundColor(.red)
-                }
-                else {
-                    Text("확인 불가")
-                        .font(.headline)
-                        .foregroundColor(.orange)
-                }
-                Spacer()
-                if selectedStation.chargers[0].isACSlow {
-                    Text("완속 ")
-                        .font(.headline)
-                }
-                else {
-                    Text("급속 ")
-                        .font(.headline)
-                }
-                Text("\(selectedStation.state) / \(selectedStation.chargers.count)")
-                    .font(.headline)
-            }.padding(.horizontal, 20)
-             
-        }.padding(.bottom, 20)
-        // onTapGesture occurs even if press the blank space
-        .background(Color.white)
-        .onTapGesture {
-            print("simple view -> detail view")
+                }.padding(.horizontal, 20)
+                 
+            }.padding(.bottom, 20)
         }
-        .onAppear(){
-            print(selectedStation.state)
-        }
+        .fullScreenCover(isPresented: $showingStationDetailSheet, content: {
+            StationDetailView().environmentObject(selectedStation)
+        })
         .onDisappear(){
             print("dismiss \(selectedStation.stationName) simple view")
         }


### PR DESCRIPTION
resolved: #17 

**구현 사항**
- 사용자가 선택한 충전소에 대해 자세한 정보를 담은 시트를 보여준다
이를 위해 다음과 같은 변수를 추가한다
    - `StationListItem`에 운영기관인 `businessName` 추가
    - `ChargerListItem`에 충전기의 출력값인 `output`과 충전기의 1kWh당 가격인 `price`를 추가
- `MapView`에서 충전소 핀의 색을 delay 없이 바로 보여주기 위해 기존의 `StationListItem`에서 현재 사용가능한 충전기의 개수인 `state`와 이를 계산하던 함수를 삭제하고 서버에서 받아올 수 있도록 `enableChargers` 추가

**수정 사항**
- `StationDetailView`에 접근하는 방법의 통일성을 높이기 위해 `StationListView`를 Partial Sheet로 변경
- `StationListView`에서 바로 접근하지 않고 `StationRowView`에서 `.onTapGesture()`를 이용하여 `StationDetailView`에 접근