### PR TITLE
Showing stations in order of distance and price

### DIFF
--- a/evinfo/StationDetailView.swift
+++ b/evinfo/StationDetailView.swift
@@ -82,6 +82,16 @@ struct StationDetailView: View {
                                     .font(.headline)
                                     .foregroundColor(.red)
                             }
+                            else if selectedStation.chargers[i].chargerStat == "STOPPED" {
+                                Text("운영 중지")
+                                    .font(.headline)
+                                    .foregroundColor(.orange)
+                            }
+                            else if selectedStation.chargers[i].chargerStat == "CHECKING" {
+                                Text("점검 진행")
+                                    .font(.headline)
+                                    .foregroundColor(.orange)
+                            }
                             else {
                                 Text("확인 불가")
                                     .font(.headline)

--- a/evinfo/StationListItem.swift
+++ b/evinfo/StationListItem.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class StationListItem: Identifiable, Codable, ObservableObject {
+class StationListItem: Identifiable, Codable, ObservableObject, Comparable {
     var id = UUID()
     var stationName: String
     var stationId: String
@@ -72,6 +72,20 @@ class StationListItem: Identifiable, Codable, ObservableObject {
         for i in 0..<fromItem.chargers.count {
             let item = fromItem.chargers[i]
             toItem.chargers.append(item)
+        }
+    }
+    
+    // comparison between stations is based on the price
+    static func < (lhs: StationListItem, rhs: StationListItem) -> Bool {
+        return lhs.chargers[0].price < rhs.chargers[0].price
+    }
+    
+    static func == (lhs: StationListItem, rhs: StationListItem) -> Bool {
+        if lhs.chargers.count > 0 && rhs.chargers.count > 0 {
+            return lhs.chargers[0].price == rhs.chargers[0].price
+        }
+        else {
+            return false
         }
     }
 }

--- a/evinfo/StationListView.swift
+++ b/evinfo/StationListView.swift
@@ -9,27 +9,75 @@ import SwiftUI
 
 struct StationListView: View {
 
+    // the list of stations in order of distance
     @EnvironmentObject var stationList: StationList
+    
+    // station that the user choose to look closely
     @EnvironmentObject var selectedStation: StationListItem
+    
+    // the list of stations in order of price
+    @State var sortedStationList: [StationListItem] = []
+    
+    // flag indicating whether stations are sorted in order of price
+    @State private var sorted = false
     
     // dismiss view flag
     @Environment(\.presentationMode) var presentationMode
     
+    
     var body: some View {
         VStack{
+            // sort criteria selection button (distance / price)
+            HStack {
+                Spacer()
+                Button(action: {
+                    sorted.toggle()
+                }) {
+                    if sorted {
+                        Text("▼ 가격순")
+                            .fontWeight(.semibold)
+                            .font(.subheadline)
+                    }
+                    else {
+                        Text("▼ 거리순")
+                            .fontWeight(.semibold)
+                            .font(.subheadline)
+                    }
+                }
+                .padding(10)
+                .foregroundColor(.white)
+                .background(Color.blue)
+                .cornerRadius(30)
+                .padding(.trailing, 10)
+            }
             // show station list
             List{
                 VStack{
-                    ForEach(0..<stationList.items.count){
-                    index in
-                            StationRowView(stationListItem: $stationList.items[index])
-                                .environmentObject(selectedStation)
-                                .background(Color.white)
-                    } // End of ForEach
+                    // order of price
+                    if sorted {
+                        ForEach(0..<sortedStationList.count){
+                        index in
+                                StationRowView(stationListItem: $sortedStationList[index])
+                                    .environmentObject(selectedStation)
+                                    .background(Color.white)
+                        }
+                    }
+                    // order of distance
+                    else {
+                        ForEach(0..<stationList.items.count){
+                        index in
+                                StationRowView(stationListItem: $stationList.items[index])
+                                    .environmentObject(selectedStation)
+                                    .background(Color.white)
+                        }
+                    }
                 }
-            }
+            } // End of List
         }
         .background(Color.white)
+        .onAppear(){
+            sortedStationList = stationList.items.sorted(by: <)
+        }
     } // End of View
 }
 /*

--- a/evinfo/StationRowView.swift
+++ b/evinfo/StationRowView.swift
@@ -31,12 +31,12 @@ struct StationRowView: View {
             }
             HStack{
                 if stationListItem.distance < 1.0 {
-                    Text("\(Int(round(stationListItem.distance * 1000)))m")
+                    Text("\(Int(round(stationListItem.distance * 1000)))m | 1kWh당 "+String(format: "%.1f", stationListItem.chargers[0].price)+"원")
                         .font(.callout)
                         .foregroundColor(.red)
                 }
                 else {
-                    Text(String(format: "%.1f", stationListItem.distance) + "km")
+                    Text(String(format: "%.1f", stationListItem.distance) + "km | 1kWh당 "+String(format: "%.1f", stationListItem.chargers[0].price)+"원")
                         .font(.callout)
                         .foregroundColor(.red)
                 }

--- a/evinfo/StationSimpleView.swift
+++ b/evinfo/StationSimpleView.swift
@@ -42,12 +42,12 @@ struct StationSimpleView: View {
                 }
                 HStack{
                     if selectedStation.distance < 1.0 {
-                        Text("\(Int(round(selectedStation.distance * 1000)))m")
+                        Text("\(Int(round(selectedStation.distance * 1000)))m | 1kWh당 "+String(format: "%.1f", selectedStation.chargers[0].price)+"원")
                             .font(.callout)
                             .foregroundColor(.red)
                     }
                     else {
-                        Text(String(format: "%.1f", selectedStation.distance) + "km")
+                        Text(String(format: "%.1f", selectedStation.distance) + "km | 1kWh당 "+String(format: "%.1f", selectedStation.chargers[0].price)+"원")
                             .font(.callout)
                             .foregroundColor(.red)
                     }


### PR DESCRIPTION
resolved : #19 

**구현 사항**
- 서버에서 거리순 정렬로 받아 온 충전소 데이터를 가격순으로 정렬하여 `sorted Station List`에 저장한다
- `Station List View`가 `.onAppear()` 시에 리스트를 정렬한다
- 리스트를 정렬하기 위해 `Station List Item`을 `Comparable` 하도록 한다
이를 위해 해당 class에서 `static func <`와 `static func ==` 를 충전 가격에 따라 비교하도록 override 한다
- 해당 뷰에서 사용자가 거리순/가격순 버튼을 토글할 때마다 각 기준에 따라 정렬된 충전소 리스트를 보여준다